### PR TITLE
Nurego-ruby tests: Fix test url; entitlements test: fix feature_id, and disable

### DIFF
--- a/spec/integration/entitlements_spec.rb
+++ b/spec/integration/entitlements_spec.rb
@@ -11,13 +11,16 @@ describe "Entitlements" do
 
     customer = Nurego::Customer.me
     organization = customer.organizations[0]
-    ents = organization.entitlements(nil, organization[:external_id])
+    # TODO(mweaver): Support internal id's in the entitlements API. New
+    # organizations do not have a external id (for good reason).
+    pending('Support for internal org id in the entitlements API')
+    ents = organization.entitlements(nil, organization[:id])
 
-    customers_ent = organization.entitlements('imported_customers')
+    customers_ent = organization.entitlements('subscribers')
 
     feature_id = customers_ent[0][:id]
     max_amount = customers_ent[0][:max_allowed_amount]
-    ent = Nurego::Entitlement.new({id: organization[:external_id]})
+    ent = Nurego::Entitlement.new({id: organization[:id]})
 
     ent.set_usage(feature_id, max_amount - 1)
 

--- a/spec/integration/spec_helper.rb
+++ b/spec/integration/spec_helper.rb
@@ -5,7 +5,7 @@ EXAMPLE_EMAIL = "integration.test+#{UUIDTools::UUID.random_create.to_s}@openskym
 EXAMPLE_PASSWORD = "password"
 
 def setup_nurego_lib(no_register = false)
-  Nurego.api_base = ENV['API_BASE'] || "http://localhost:31001/"
+  Nurego.api_base = ENV['API_BASE'] || "http://localhost:31001"
   Nurego.api_key = ENV['NUREGO_API_KEY_TEST'] || 'tee00d77-d6f2-4f8d-8897-26fb89fbeb34'
 
   register unless no_register


### PR DESCRIPTION
entitlement test until backend can support it.

I know you guys (@gilderman , @anatb) had a lot of discussion re. internal_id vs. external_id, but I can't find that thread. Not sure how you planned to handle this, but I added a TODO that gives my recommendation.
